### PR TITLE
Removed dead links to IFP

### DIFF
--- a/src/pages/apps.md
+++ b/src/pages/apps.md
@@ -1,7 +1,7 @@
 ---
 title: "IFP Apps"
 ---
-Scouras Consulting is offering a growing list of apps, available at [Imagine's IFP Marketplace](http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting "Imagine's IFP Marketplace")
+Scouras Consulting is offering a growing list of apps, available at Imagine's IFP Marketplace
 
 ### [RSI CUSTOM, PROVIDES RELATIVE STRENGTH INDEX](/rsicustom/)
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,17 +24,7 @@ const HomePage = () => (
                 marginBottom: '2rem',
               }}
             >
-              Scouras Consulting is an Imagine partner building apps for the{' '}
-              <a
-                href="http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting"
-                style={{
-                  background: 'none',
-                  color: 'rgb(233,233,233)',
-                  textDecoration: 'underline',
-                }}
-              >
-                Imagine Financial Platform (IFP)
-              </a>
+              Scouras Consulting is an Imagine partner building apps for the Imagine Financial Platform (IFP)
             </h1>
             <p>
               In addition to outlining the benefits and features of our apps, we
@@ -43,17 +33,7 @@ const HomePage = () => (
             </p>
             <p>
               A new version of ImagineMobile has been released that includes the
-              functionality of{' '}
-              <a
-                href="https://www2.derivatives.com/users/docs/rest/mr82310.htm"
-                style={{
-                  background: 'none',
-                  color: 'rgb(233,233,233)',
-                  textDecoration: 'underline',
-                }}
-              >
-                Imagine's REST API changes.
-              </a>
+              functionality of Imagine's REST API changes.
             </p>
 
             <p>

--- a/src/pages/multivariate.md
+++ b/src/pages/multivariate.md
@@ -20,7 +20,7 @@ Our MVB Integrator app provides the following key features:
 
 For information on our pricing and our support policies, please visit our [pricing](/pricing) and our [support](/support) pages.
 
-Once the MVB Integrator app is obtained form [Imagine's IFP Marketplace](http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting), you can run the generator app (sc.MVB.gen.js) which is found in your 'MyApp' section of the App Explorer.
+Once the MVB Integrator app is obtained form Imagine's IFP Marketplace, you can run the generator app (sc.MVB.gen.js) which is found in your 'MyApp' section of the App Explorer.
 
 ![MVB Integrator - My App ](../images/mvb_myapp.png)
 

--- a/src/pages/pricing.md
+++ b/src/pages/pricing.md
@@ -1,7 +1,7 @@
 ---
 title: "IFP Apps Pricing"
 ---
-Scouras Consulting is offering a growing list of apps, available at [Imagine's IFP Marketplace](http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting "Imagine's IFP Marketplace")
+Scouras Consulting is offering a growing list of apps, available at Imagine's IFP Markedtplace
 
 - **RSI CUSTOM PROVIDES RELATIVE STRENGTH INDEX**
 

--- a/src/pages/rsicustom.md
+++ b/src/pages/rsicustom.md
@@ -19,7 +19,7 @@ Our RSI Custom app provides the following key features:
 
 For information on our pricing and our support policies, please visit our [pricing](/pricing/) and [support](/support/) pages.
 
-Once the RSI Custom app is obtained from [Imagine's IFP Marketplace](http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting "Imagine's IFP Marketplace"), set up your Custom Columns as shown below. If you're using a 14 day RSI, there is no need for parameters:
+Once the RSI Custom app is obtained from Imagine's IFP Marketplace, set up your Custom Columns as shown below. If you're using a 14 day RSI, there is no need for parameters:
 
 ![RSI 14 Day Configuration](../images/rsi_14.png)
 

--- a/src/pages/support.md
+++ b/src/pages/support.md
@@ -1,7 +1,7 @@
 ---
 title: "IFP Apps - Support"
 ---
-Scouras Consulting is offering a growing list of apps, available at [Imagine's IFP Marketplace](http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting "Imagine's IFP Marketplace")
+Scouras Consulting is offering a growing list of apps, available at Imagine's IFP Marketplace
 
 Scouras Consulting offers support for all of our apps [via email](mailto:consulting@scouras.com) with a policy to respond to all support requests within 24 hours.
 

--- a/src/pages/techextend.md
+++ b/src/pages/techextend.md
@@ -16,7 +16,7 @@ The TechExtend app enables you to:
 - RSI - Relative Strength Index
 - MACD - Moving Average Convergence/Divergence
 
-TechExtend is available at [Imagine's IFP app marketplace](http://marketplace.derivatives.com/collections/vendors?q=Scouras+Consulting)
+TechExtend is available at Imagine's IFP app marketplace
 
 The screen capture below is output form a portfolio setup utilizing the app. If a returned value is negative, please refer to the [TechExtend Error Codes](#techextend_support) section.
 


### PR DESCRIPTION
Links to Imagine's Marketplace were leading to 403 and 421 errors. 